### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ In practice, the purpose of those is, in fact, to enable code that can be read i
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.reverse "0.2.0"]
+[com.nedap.staffing-solutions/utils.reverse "1.0.0"]
 ````
 
 ## Synopsis

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.reverse "0.2.0"
+(defproject com.nedap.staffing-solutions/utils.reverse "1.0.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[org.clojure/clojure "1.10.1"]]
 
-  :description "hreading macros and HOFs for doing things in reverse order, increasing readability."
+  :description "Threading macros and HOFs for doing things in reverse order, increasing readability."
 
   :url "https://github.com/nedap/utils.reverse"
 


### PR DESCRIPTION
Delivers: https://github.com/nedap/utils.reverse/pull/2

No functional changes. The 1.x release denotes stability and is also needed for a first Clojars deploy.

## Release checklist (author)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] The build passes
* [x] New features are (briefly) reflected in the README

## Release checklist (reviewer)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] New features are (briefly) reflected in the README
